### PR TITLE
Fixed a problem with the 'dropProprietaryTags' configuration property.

### DIFF
--- a/src/main/java/org/w3c/tidy/ParserImpl.java
+++ b/src/main/java/org/w3c/tidy/ParserImpl.java
@@ -707,6 +707,13 @@ public final class ParserImpl
 
             while ((node = lexer.getToken(mode)) != null)
             {
+              if (node.tag == null)
+              {
+              	if(!lexer.configuration.dropProprietaryTags) 
+              	{
+              		node.tag = new Dict(node.element, Dict.VERS_ALL, Dict.CM_BLOCK, ParserImpl.BLOCK, null);
+              	}
+              }
 
                 // #538536 Extra endtags not detected
                 if (node.tag == tt.tagHtml)


### PR DESCRIPTION
Hi,

An unknown element is removed when is direct child of 'body' element, even if I set the 'dropProprietaryTags' to false.

For example, the _math_ element is removed, for the following HTML file:
[htmlWithUnknownTags.txt](https://github.com/jtidy/jtidy/files/3405660/htmlWithUnknownTags.txt)

I added a fix for this problem.

Thanks, 
Cosmin