### PR TITLE
Fixed a NPE

### DIFF
--- a/src/main/java/org/w3c/tidy/PPrint.java
+++ b/src/main/java/org/w3c/tidy/PPrint.java
@@ -1381,7 +1381,7 @@ public class PPrint
 
         if (prev != null)
         {
-            if (prev.type == Node.TEXT_NODE && prev.end > prev.start)
+            if (prev.type == Node.TEXT_NODE && prev.end > prev.start && prev.textarray != null)
             {
                 c = (prev.textarray[prev.end - 1]) & 0xFF; // Convert to unsigned.
 


### PR DESCRIPTION
A NPE is throws when parsing the  "`<br />`"  element.
```
java.lang.NullPointerException
	at org.w3c.tidy.PPrint.afterSpace(PPrint.java:1398)
	at org.w3c.tidy.PPrint.afterSpace(PPrint.java:1406)
	at org.w3c.tidy.PPrint.printTag(PPrint.java:1463)
	at org.w3c.tidy.PPrint.printTree(PPrint.java:2276)
	at org.w3c.tidy.PPrint.printTree(PPrint.java:2386)
	at org.w3c.tidy.PPrint.printTree(PPrint.java:2443)
	at org.w3c.tidy.PPrint.printTree(PPrint.java:2443)
	at org.w3c.tidy.PPrint.printTree(PPrint.java:2443)
	at org.w3c.tidy.PPrint.printTree(PPrint.java:2219)
	at org.w3c.tidy.Tidy.parse(Tidy.java:620)
```