### PR TITLE
Parse source element as an empty element.

### DIFF
--- a/src/main/java/org/w3c/tidy/TagTable.java
+++ b/src/main/java/org/w3c/tidy/TagTable.java
@@ -334,7 +334,7 @@ public final class TagTable
         new Dict("output", Dict.VERS_XHTML11, Dict.CM_INLINE, ParserImpl.INLINE, null),
         new Dict("audio", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
         new Dict("video", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
-        new Dict("source", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
+        new Dict("source", Dict.VERS_HTML5,  (Dict.CM_BLOCK | Dict.CM_EMPTY), ParserImpl.EMPTY, null),
         new Dict("track", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
         new Dict("embed", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
         new Dict("picture", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),


### PR DESCRIPTION
Hello,
When I process an audio element with source elements like this:
`<audio>
            <source src="horse.ogg" type="audio/ogg">
            <source src="horse.mp3" type="audio/mpeg">
            Your browser does not support the audio element.
  </audio>`

I will obtain this invalid structure:
`        <audio>
            <source src="horse.ogg" type="audio/ogg">
                <source src="horse.mp3" type="audio/mpeg">Your browser does not support the audio
                    element.</source>
            </source>
        </audio>`

This happens because the source element is not parsed as an empty element.