### PR TITLE
Add rudimentary suport for HTML5 canvas and svg element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target
 *~
 .idea
 .envrc
+/.classpath
+/.project
+/.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -138,25 +138,25 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.11</version>
+            <version>1.10.13</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -136,11 +136,6 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-            <version>2.12.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
             <version>1.10.11</version>

--- a/src/main/java/org/w3c/tidy/TagTable.java
+++ b/src/main/java/org/w3c/tidy/TagTable.java
@@ -334,6 +334,8 @@ public final class TagTable
         new Dict("output", Dict.VERS_XHTML11, Dict.CM_INLINE, ParserImpl.INLINE, null),
         new Dict("audio", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
         new Dict("video", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
+        new Dict("canvas", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
+        new Dict("svg", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
         new Dict("source", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
         new Dict("track", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
         new Dict("embed", Dict.VERS_HTML5, Dict.CM_BLOCK, ParserImpl.BLOCK, null),
@@ -931,6 +933,8 @@ public final class TagTable
         tagSource = lookup("source");
         tagTrack = lookup("track");
         tagVideo = lookup("video");
+        tagCanvas = lookup("canvas");
+        tagSvg = lookup("svg");
         tagPicture = lookup("picture");
     }
 

--- a/src/test/java/org/w3c/tidy/JTidyWarningBugsTest.java
+++ b/src/test/java/org/w3c/tidy/JTidyWarningBugsTest.java
@@ -82,6 +82,17 @@ public class JTidyWarningBugsTest extends TidyTestCase
     }
 
     /**
+     * test for JTidy accepting <code>canvas</code> elements.
+     * @throws Exception any exception generated during the test
+     */
+    public void testCanvas() throws Exception
+    {
+    	executeTidyTest("test-canvas.html");
+    	assertNoWarnings();
+    	assertNoErrors();
+    }
+    
+    /**
      * test for JTidy [444834]: Silent Option.
      * @throws Exception any exception generated during the test
      */

--- a/src/test/resources/1003994.msg
+++ b/src/test/resources/1003994.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 1003994-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>13</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/1024661.msg
+++ b/src/test/resources/1024661.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 1024661-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>68</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/426885.msg
+++ b/src/test/resources/426885.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 426885-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427633.msg
+++ b/src/test/resources/427633.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427633-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427662.msg
+++ b/src/test/resources/427662.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427662-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427664.msg
+++ b/src/test/resources/427664.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427664-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>
@@ -22,7 +13,7 @@ Tidy (vers 4th August 2004) Parsing "InputStream"
     <level>2</level>
     <line>5</line>
     <column>1</column>
-    <text><![CDATA[<body> attribute "Ã1/2" has invalid value "xx"]]></text>
+    <text><![CDATA[<body> attribute "ï¿½1/2" has invalid value "xx"]]></text>
   </message>
   <message>
     <code>59</code>

--- a/src/test/resources/427671.msg
+++ b/src/test/resources/427671.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427671-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427672.msg
+++ b/src/test/resources/427672.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427672-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>
@@ -22,7 +13,7 @@ Tidy (vers 4th August 2004) Parsing "InputStream"
     <level>2</level>
     <line>5</line>
     <column>1</column>
-    <text><![CDATA[<body> attribute "Ã1/2" has invalid value "xx"]]></text>
+    <text><![CDATA[<body> attribute "ï¿½1/2" has invalid value "xx"]]></text>
   </message>
   <message>
     <code>111</code>

--- a/src/test/resources/427675.msg
+++ b/src/test/resources/427675.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427675-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427676.msg
+++ b/src/test/resources/427676.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427676-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427677.msg
+++ b/src/test/resources/427677.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427677-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427810.msg
+++ b/src/test/resources/427810.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427810-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427811.msg
+++ b/src/test/resources/427811.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427811-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427812.msg
+++ b/src/test/resources/427812.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427812-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/427813.msg
+++ b/src/test/resources/427813.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427813-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427816.msg
+++ b/src/test/resources/427816.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427816-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427818.msg
+++ b/src/test/resources/427818.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427818-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>65</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/427819.msg
+++ b/src/test/resources/427819.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427819-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427820.msg
+++ b/src/test/resources/427820.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427820-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427821.msg
+++ b/src/test/resources/427821.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427821-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/427822.msg
+++ b/src/test/resources/427822.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427822-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427823.msg
+++ b/src/test/resources/427823.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427823-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427825.msg
+++ b/src/test/resources/427825.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427825-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>2</line>

--- a/src/test/resources/427826.msg
+++ b/src/test/resources/427826.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427826-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>32</code>
     <level>2</level>
     <line>13</line>

--- a/src/test/resources/427827.msg
+++ b/src/test/resources/427827.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427827-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>7</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/427830.msg
+++ b/src/test/resources/427830.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427830-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>2</line>

--- a/src/test/resources/427833.msg
+++ b/src/test/resources/427833.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427833-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>3</code>
     <level>2</level>
     <line>10</line>

--- a/src/test/resources/427834.msg
+++ b/src/test/resources/427834.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427834-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/427835.msg
+++ b/src/test/resources/427835.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427835-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>2</line>

--- a/src/test/resources/427836.msg
+++ b/src/test/resources/427836.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427836-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427837.msg
+++ b/src/test/resources/427837.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/427838.msg
+++ b/src/test/resources/427838.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427838-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>7</code>
     <level>2</level>
     <line>11</line>

--- a/src/test/resources/427839.msg
+++ b/src/test/resources/427839.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427839-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427841.msg
+++ b/src/test/resources/427841.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427841-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/427844.msg
+++ b/src/test/resources/427844.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427844-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/427845.msg
+++ b/src/test/resources/427845.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427845-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/427846.msg
+++ b/src/test/resources/427846.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 427846-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/431716.msg
+++ b/src/test/resources/431716.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431716-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/431719.msg
+++ b/src/test/resources/431719.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431719-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/431721.msg
+++ b/src/test/resources/431721.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431721-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>48</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/431731.msg
+++ b/src/test/resources/431731.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431731-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/431736.msg
+++ b/src/test/resources/431736.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431736-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>2</line>

--- a/src/test/resources/431739.msg
+++ b/src/test/resources/431739.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431739-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/431874.msg
+++ b/src/test/resources/431874.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431874-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>7</code>
     <level>2</level>
     <line>5</line>

--- a/src/test/resources/431883.msg
+++ b/src/test/resources/431883.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431883-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/431889.msg
+++ b/src/test/resources/431889.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431889-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>49</code>
     <level>2</level>
     <line>35</line>

--- a/src/test/resources/431898.msg
+++ b/src/test/resources/431898.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431898-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>3</code>
     <level>2</level>
     <line>11</line>

--- a/src/test/resources/431956.msg
+++ b/src/test/resources/431956.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/431958.msg
+++ b/src/test/resources/431958.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431958-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/431964.msg
+++ b/src/test/resources/431964.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431964-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>51</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/431965.msg
+++ b/src/test/resources/431965.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 431965-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/432677.msg
+++ b/src/test/resources/432677.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 432677-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/433012.msg
+++ b/src/test/resources/433012.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433012-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/433021.msg
+++ b/src/test/resources/433021.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433021-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>51</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/433040.msg
+++ b/src/test/resources/433040.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433040-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/433359.msg
+++ b/src/test/resources/433359.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433359-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/433360.msg
+++ b/src/test/resources/433360.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433360-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/433604.msg
+++ b/src/test/resources/433604.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/433607.msg
+++ b/src/test/resources/433607.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/433656.msg
+++ b/src/test/resources/433656.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433656-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/433666.msg
+++ b/src/test/resources/433666.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433666-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/433670.msg
+++ b/src/test/resources/433670.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433670-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>3</code>
     <level>2</level>
     <line>4</line>

--- a/src/test/resources/433672.msg
+++ b/src/test/resources/433672.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433672-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/433856.msg
+++ b/src/test/resources/433856.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 433856-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/434047.msg
+++ b/src/test/resources/434047.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 434047-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>28</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/434100.msg
+++ b/src/test/resources/434100.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 434100-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>13</code>
     <level>3</level>
     <line>13</line>

--- a/src/test/resources/434940.msg
+++ b/src/test/resources/434940.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 434940-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/434940b.msg
+++ b/src/test/resources/434940b.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 434940b-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/435903.msg
+++ b/src/test/resources/435903.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 435903-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/435909.msg
+++ b/src/test/resources/435909.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 435909-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>11</code>
     <level>2</level>
     <line>22</line>

--- a/src/test/resources/435917.msg
+++ b/src/test/resources/435917.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 435917-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>58</code>
     <level>2</level>
     <line>11</line>

--- a/src/test/resources/435919.msg
+++ b/src/test/resources/435919.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 435919-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/435920.msg
+++ b/src/test/resources/435920.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 435920-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/435922.msg
+++ b/src/test/resources/435922.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 435922-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>11</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/435923.msg
+++ b/src/test/resources/435923.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 435923-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/437468.msg
+++ b/src/test/resources/437468.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 437468-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/438650.msg
+++ b/src/test/resources/438650.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 438650-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/438658.msg
+++ b/src/test/resources/438658.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 438658-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/438954.msg
+++ b/src/test/resources/438954.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 438954-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/438956.msg
+++ b/src/test/resources/438956.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 438956-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>11</code>
     <level>2</level>
     <line>5</line>

--- a/src/test/resources/441508.msg
+++ b/src/test/resources/441508.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 441508-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/441568.msg
+++ b/src/test/resources/441568.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 441568-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/441740.msg
+++ b/src/test/resources/441740.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 441740-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/443362.msg
+++ b/src/test/resources/443362.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 443362-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>39</code>
     <level>2</level>
     <line>26</line>

--- a/src/test/resources/443381.msg
+++ b/src/test/resources/443381.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 443381-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/443576.msg
+++ b/src/test/resources/443576.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 443576-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/443678.msg
+++ b/src/test/resources/443678.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 443678-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/444394.msg
+++ b/src/test/resources/444394.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 444394-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>48</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/445074.msg
+++ b/src/test/resources/445074.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 445074-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>70</code>
     <level>2</level>
     <line>8</line>

--- a/src/test/resources/445394.msg
+++ b/src/test/resources/445394.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 445394-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/445557.msg
+++ b/src/test/resources/445557.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 445557-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/446019.msg
+++ b/src/test/resources/446019.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 446019-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/449348.msg
+++ b/src/test/resources/449348.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 449348-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/450389.msg
+++ b/src/test/resources/450389.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 450389-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/456596.msg
+++ b/src/test/resources/456596.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 456596-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/463066.msg
+++ b/src/test/resources/463066.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 463066-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>29</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/467863.msg
+++ b/src/test/resources/467863.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 467863-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>7</code>
     <level>2</level>
     <line>6</line>

--- a/src/test/resources/467865.msg
+++ b/src/test/resources/467865.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 467865-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>24</code>
     <level>1</level>
     <line>6</line>

--- a/src/test/resources/470663.msg
+++ b/src/test/resources/470663.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 470663-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>48</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/470688.msg
+++ b/src/test/resources/470688.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 470688-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>10</code>
     <level>2</level>
     <line>8</line>

--- a/src/test/resources/471264.msg
+++ b/src/test/resources/471264.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 471264-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/475643.msg
+++ b/src/test/resources/475643.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 475643-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/480406.msg
+++ b/src/test/resources/480406.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/480701.msg
+++ b/src/test/resources/480701.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/480843.msg
+++ b/src/test/resources/480843.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 480843-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>11</code>
     <level>2</level>
     <line>6</line>

--- a/src/test/resources/487204.msg
+++ b/src/test/resources/487204.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 487204-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>12</code>
     <level>2</level>
     <line>6</line>

--- a/src/test/resources/487283.msg
+++ b/src/test/resources/487283.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 487283-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/500236.msg
+++ b/src/test/resources/500236.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 500236-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>29</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/501230.msg
+++ b/src/test/resources/501230.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 501230-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>53</code>
     <level>2</level>
     <line>8</line>

--- a/src/test/resources/501669.msg
+++ b/src/test/resources/501669.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 501669-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/502346.msg
+++ b/src/test/resources/502346.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 502346-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/502348.msg
+++ b/src/test/resources/502348.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 502348-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>50</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/503436.msg
+++ b/src/test/resources/503436.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/504206.msg
+++ b/src/test/resources/504206.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 504206-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/505770.msg
+++ b/src/test/resources/505770.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 505770-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/508245.msg
+++ b/src/test/resources/508245.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 508245-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/508936.msg
+++ b/src/test/resources/508936.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 508936-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/511243.msg
+++ b/src/test/resources/511243.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 511243-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>78</code>
     <level>2</level>
     <line>11</line>

--- a/src/test/resources/511679.msg
+++ b/src/test/resources/511679.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 511679-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/514348.msg
+++ b/src/test/resources/514348.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 514348-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/514893.msg
+++ b/src/test/resources/514893.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 514893-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/516370.msg
+++ b/src/test/resources/516370.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 516370-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>71</code>
     <level>2</level>
     <line>10</line>

--- a/src/test/resources/517528.msg
+++ b/src/test/resources/517528.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 517528-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/517550.msg
+++ b/src/test/resources/517550.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 517550-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/525081.msg
+++ b/src/test/resources/525081.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 525081-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/527118.msg
+++ b/src/test/resources/527118.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 527118-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/531964.msg
+++ b/src/test/resources/531964.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 531964-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>23</code>
     <level>2</level>
     <line>9</line>

--- a/src/test/resources/532535.msg
+++ b/src/test/resources/532535.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 532535-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>21</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/533105.msg
+++ b/src/test/resources/533105.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 533105-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>32</code>
     <level>2</level>
     <line>12</line>

--- a/src/test/resources/533233.msg
+++ b/src/test/resources/533233.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 533233-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/537604.msg
+++ b/src/test/resources/537604.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 537604-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>3</code>
     <level>2</level>
     <line>5</line>

--- a/src/test/resources/538536.msg
+++ b/src/test/resources/538536.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 538536-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>27</code>
     <level>2</level>
     <line>8</line>

--- a/src/test/resources/538727.msg
+++ b/src/test/resources/538727.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 538727-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/539369.msg
+++ b/src/test/resources/539369.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 539369-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>8</code>
     <level>2</level>
     <line>19</line>

--- a/src/test/resources/539369a.msg
+++ b/src/test/resources/539369a.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 539369a-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>7</code>
     <level>2</level>
     <line>14</line>

--- a/src/test/resources/540045.msg
+++ b/src/test/resources/540045.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 540045-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/540296.msg
+++ b/src/test/resources/540296.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 540296-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/540555.msg
+++ b/src/test/resources/540555.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 540555-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/540571.msg
+++ b/src/test/resources/540571.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 540571-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/542029.msg
+++ b/src/test/resources/542029.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 542029-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/545067.msg
+++ b/src/test/resources/545067.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 545067-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>23</code>
     <level>2</level>
     <line>4</line>

--- a/src/test/resources/545772.msg
+++ b/src/test/resources/545772.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 545772-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/547976.msg
+++ b/src/test/resources/547976.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 547976-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>70</code>
     <level>2</level>
     <line>9</line>

--- a/src/test/resources/552861.msg
+++ b/src/test/resources/552861.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 552861-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/553414.msg
+++ b/src/test/resources/553414.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 553414-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/553468.msg
+++ b/src/test/resources/553468.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 553468-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/566542.msg
+++ b/src/test/resources/566542.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 566542-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/572154.msg
+++ b/src/test/resources/572154.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 572154-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/574158.msg
+++ b/src/test/resources/574158.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 574158-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>7</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/578216.msg
+++ b/src/test/resources/578216.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 578216-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>2</line>

--- a/src/test/resources/586562.msg
+++ b/src/test/resources/586562.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 586562-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>34</code>
     <level>2</level>
     <line>5</line>

--- a/src/test/resources/588061.msg
+++ b/src/test/resources/588061.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 588061-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/593705.msg
+++ b/src/test/resources/593705.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 593705-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/598860.msg
+++ b/src/test/resources/598860.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 598860-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/603128.msg
+++ b/src/test/resources/603128.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 603128-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/610244.msg
+++ b/src/test/resources/610244.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 610244-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/616744.msg
+++ b/src/test/resources/616744.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/620531.msg
+++ b/src/test/resources/620531.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 620531-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/629885.msg
+++ b/src/test/resources/629885.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 629885-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/634889.msg
+++ b/src/test/resources/634889.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 634889-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/640473.msg
+++ b/src/test/resources/640473.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 640473-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/640474.msg
+++ b/src/test/resources/640474.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/646946.msg
+++ b/src/test/resources/646946.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/647255.msg
+++ b/src/test/resources/647255.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 647255-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/647900.msg
+++ b/src/test/resources/647900.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 647900-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/648768.msg
+++ b/src/test/resources/648768.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 648768-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/649812.msg
+++ b/src/test/resources/649812.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 649812-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/655338.msg
+++ b/src/test/resources/655338.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 655338-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>57</code>
     <level>2</level>
     <line>3</line>

--- a/src/test/resources/656889.msg
+++ b/src/test/resources/656889.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 656889-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/658230.msg
+++ b/src/test/resources/658230.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 658230-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/660397.msg
+++ b/src/test/resources/660397.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 660397-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>17</code>
     <level>2</level>
     <line>5</line>

--- a/src/test/resources/661606.msg
+++ b/src/test/resources/661606.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 661606-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/663197.msg
+++ b/src/test/resources/663197.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 663197-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/663548.msg
+++ b/src/test/resources/663548.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 663548-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/671087.msg
+++ b/src/test/resources/671087.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 671087-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/676156.msg
+++ b/src/test/resources/676156.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 676156-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/676205.msg
+++ b/src/test/resources/676205.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 676205-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>3</line>

--- a/src/test/resources/678268.msg
+++ b/src/test/resources/678268.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 678268-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>48</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/679135.msg
+++ b/src/test/resources/679135.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 679135-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>2</line>

--- a/src/test/resources/680664.msg
+++ b/src/test/resources/680664.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 680664-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>29</code>
     <level>2</level>
     <line>13</line>

--- a/src/test/resources/688746.msg
+++ b/src/test/resources/688746.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 688746-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/695408.msg
+++ b/src/test/resources/695408.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 695408-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/696799.msg
+++ b/src/test/resources/696799.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 696799-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/706260.msg
+++ b/src/test/resources/706260.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 706260-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/708322.msg
+++ b/src/test/resources/708322.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 708322-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/735603.msg
+++ b/src/test/resources/735603.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 735603-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/763186.msg
+++ b/src/test/resources/763186.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 763186-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/763191.msg
+++ b/src/test/resources/763191.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 763191-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/765852.msg
+++ b/src/test/resources/765852.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 765852-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/788031.msg
+++ b/src/test/resources/788031.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 788031-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/791933.msg
+++ b/src/test/resources/791933.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 791933-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/828316.msg
+++ b/src/test/resources/828316.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 828316-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/837023.msg
+++ b/src/test/resources/837023.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 837023-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/917012.msg
+++ b/src/test/resources/917012.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 917012-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/922302.msg
+++ b/src/test/resources/922302.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 922302-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>44</code>
     <level>2</level>
     <line>1</line>

--- a/src/test/resources/929936.msg
+++ b/src/test/resources/929936.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 929936-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>62</code>
     <level>2</level>
     <line>7</line>

--- a/src/test/resources/935796.msg
+++ b/src/test/resources/935796.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 935796-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/943559.msg
+++ b/src/test/resources/943559.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 943559-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>12</code>
     <level>2</level>
     <line>10</line>

--- a/src/test/resources/991469.msg
+++ b/src/test/resources/991469.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/991471.msg
+++ b/src/test/resources/991471.msg
@@ -6,15 +6,6 @@
     <level>0</level>
     <line>0</line>
     <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
     <text><![CDATA[no warnings or errors were found
 ]]></text>
   </message>

--- a/src/test/resources/994841.msg
+++ b/src/test/resources/994841.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 994841-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/996484.msg
+++ b/src/test/resources/996484.msg
@@ -2,15 +2,6 @@
 <!-- expected messages for test 996484-->
 <messages>
   <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[
-Tidy (vers 4th August 2004) Parsing "InputStream"
-]]></text>
-  </message>
-  <message>
     <code>110</code>
     <level>0</level>
     <line>1</line>

--- a/src/test/resources/test-canvas.html
+++ b/src/test/resources/test-canvas.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Some title</title>
+</head>
+<body>
+<canvas id="c5859-canvas"></canvas>
+</body>
+</html>

--- a/src/test/resources/test-canvas.msg
+++ b/src/test/resources/test-canvas.msg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- expected messages for test 996484-->
+<messages>
+  <message>
+    <code>110</code>
+    <level>0</level>
+    <line>1</line>
+    <column>1</column>
+    <text><![CDATA[InputStream: Doctype given is ""]]></text>
+  </message>
+  <message>
+    <code>111</code>
+    <level>0</level>
+    <line>1</line>
+    <column>1</column>
+    <text><![CDATA[InputStream: Document content looks like HTML proprietary]]></text>
+  </message>
+  <message>
+    <code>-1</code>
+    <level>0</level>
+    <line>0</line>
+    <column>0</column>
+    <text><![CDATA[no warnings or errors were found
+]]></text>
+  </message>
+</messages>


### PR DESCRIPTION
In d1e94e4154c7fb47e3cbfb0cc53c286ddecbe727 HTML5 support was announced, but the commit did not actually define the elements `canvas` and `svg`. 

Besides that I tried to fix some test cases expecting messages that are no longer logged and removed an unused dependency to xerces which causes problems with Java 11 modularized projects.