### PR TITLE
Fix: when document has excessive nesting the program fails without printing the error

### DIFF
--- a/src/main/java/org/w3c/tidy/Report.java
+++ b/src/main/java/org/w3c/tidy/Report.java
@@ -1520,6 +1520,9 @@ public final class Report
                 printMessage(code, lexer, "unexpected_endtag", new Object[]{node.element}, Level.ERROR);
             }
         }
+        else if (code == DOCUMENT_WITH_EXCESSIVE_NESTING) {
+            printMessage(code, lexer, "document_with_excessive_nesting", null, Level.ERROR);
+        }
     }
 
     /**

--- a/src/main/resources/org/w3c/tidy/TidyMessages.properties
+++ b/src/main/resources/org/w3c/tidy/TidyMessages.properties
@@ -28,6 +28,7 @@ content_after_body=content occurs after end of body
 discarding_unexpected=discarding unexpected {0}
 doctype_after_tags=<!DOCTYPE> isn't allowed after elements
 doctype_given={0}: Doctype given is "{1}"
+document_with_excessive_nesting=Document with excessive nesting
 dtype_not_upper_case=SYSTEM, PUBLIC, W3C, DTD, EN must be upper case
 duplicate_frameset=repeated FRAMESET element
 element_not_empty={0} element not empty or not closed

--- a/src/main/resources/org/w3c/tidy/TidyMessages_de.properties
+++ b/src/main/resources/org/w3c/tidy/TidyMessages_de.properties
@@ -27,6 +27,7 @@ content_after_body=Inhalt erscheint nach dem Ende von <body>.
 discarding_unexpected=entsorge unerwartetes {0}
 doctype_after_tags=<!DOCTYPE> darf nur am Anfang des Dokumentes stehen, nicht nach Elementen
 doctype_given=
+document_with_excessive_nesting=Dokument mit übermäßiger Verschachtelung
 dtype_not_upper_case=SYSTEM, PUBLIC, W3C, DTD, EN m\u00fcssen komplett in Gro\u00dfbuchstaben geschrieben werden.
 duplicate_frameset=wiederholtes <frameset>-Element
 element_not_empty=

--- a/src/main/resources/org/w3c/tidy/TidyMessages_es.properties
+++ b/src/main/resources/org/w3c/tidy/TidyMessages_es.properties
@@ -27,6 +27,7 @@ content_after_body=contenido despues del final del 'body'
 discarding_unexpected=descartando inesperado {0}
 doctype_after_tags=<!DOCTYPE> no esta permitido despu\u00e9s de elementos
 doctype_given={0}: Doctype dado es "{1}"
+document_with_excessive_nesting=Documento con anidamiento excesivo
 dtype_not_upper_case=SYSTEM, PUBLIC, W3C, DTD, EN deben ir en may\u00fasculas
 duplicate_frameset=elemento FRAMESET repetido
 element_not_empty=


### PR DESCRIPTION
This adds an error message when the parsing fails due to excessive nesting.